### PR TITLE
Apply GOV.UK font styling to the "Other type of appointment" autocomplete

### DIFF
--- a/src/client/sass/application.sass
+++ b/src/client/sass/application.sass
@@ -5,6 +5,7 @@
 
 @import '~accessible-autocomplete'
 
+@import 'components/autocomplete'
 @import 'components/header-bar'
 @import 'components/time-autocomplete'
 @import 'components/note-panel'

--- a/src/client/sass/components/_autocomplete.scss
+++ b/src/client/sass/components/_autocomplete.scss
@@ -1,0 +1,23 @@
+.autocomplete__wrapper,
+.autocomplete__input,
+.autocomplete__hint {
+  font-family: $govuk-font-family;
+}
+
+.govuk-form-group--error {
+  .autocomplete__input--default {
+    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+  }
+
+  .autocomplete__input--focused {
+    border-color: $govuk-input-border-colour;
+    // Remove `box-shadow` inherited from `:focus` as
+    // `autocomplete__input--default` already has the thicker border.
+    box-shadow: none;
+  }
+}
+
+.autocomplete__dropdown-arrow-down {
+  pointer-events: none;
+  z-index: 0;
+}


### PR DESCRIPTION
Illustration of the issue (the font in the autocomplete isn't GDS Transport) :

![image](https://user-images.githubusercontent.com/23801/125822941-84f4b651-8321-45bb-8081-886acde31316.png)


Corresponding fix in the prototype: https://github.com/ministryofjustice/hmpps-manage-supervisions-prototype/pull/283