### PR TITLE
auto login on cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
           TZ: "Europe/London"
       - image: circleci/redis:buster
       - image: rodolpheche/wiremock
-        command: ['/docker-entrypoint.sh', '--port', '9091']
+        command: ['/docker-entrypoint.sh', '--port', '9091', '--global-response-templating']
 
 commands:
   install-build-deps:

--- a/cypress/@types/cypress/index.d.ts
+++ b/cypress/@types/cypress/index.d.ts
@@ -2,7 +2,6 @@
 
 declare namespace Cypress {
   interface Chainable {
-    login(): Chainable<Element>
     home(): Chainable<Element>
     arrangeAppointment(crn: string): Chainable<Element>
     viewOffender(crn: string): Chainable<Element>

--- a/cypress/integration/arrange-appointment/dummy-data.spec.ts
+++ b/cypress/integration/arrange-appointment/dummy-data.spec.ts
@@ -37,11 +37,6 @@ context('CreateAppointment', () => {
     cy.task('stubAuthUser')
   })
 
-  it('Unauthenticated user directed to login', () => {
-    cy.arrangeAppointment('somecrn')
-    cy.task('getLoginAttempts').should('have.length', 1)
-  })
-
   it('can book an office visit appointment', () => {
     const test = testCase({
       crn: 'ABC123',
@@ -282,7 +277,6 @@ context('CreateAppointment', () => {
   }
 
   function havingLoggedInAndBeginBookingAppointmentFlow({ crn }: AppointmentBookingTestCase) {
-    cy.login()
     cy.arrangeAppointment(crn)
   }
 

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -1,7 +1,8 @@
-import { HomePage } from '../pages'
+import { HmppsAuthPage, HomePage } from '../pages'
 
 context('Home', () => {
   const homePage = new HomePage()
+  const authPage = new HmppsAuthPage()
 
   beforeEach(() => {
     cy.task('reset')
@@ -10,20 +11,13 @@ context('Home', () => {
     cy.task('stubGetStaffDetails')
   })
 
-  it('Unauthenticated user directed to login', () => {
-    cy.home()
-    cy.task('getLoginAttempts').should('have.length', 1)
-  })
-
   it('User can log out', () => {
-    cy.login()
     cy.home()
     homePage.logoutButton.click()
-    cy.task('getLogoutAttempts').should('have.length', 1)
+    authPage.shouldHaveRedirectedToLogoutPage()
   })
 
   it('Page furniture rendered', () => {
-    cy.login()
     cy.home()
     homePage.pageTitle.contains('This site is under construction...')
     homePage.headerUserName.should('contain.text', 'J. Smith')

--- a/cypress/integration/offenders/offender/offender-overview.spec.ts
+++ b/cypress/integration/offenders/offender/offender-overview.spec.ts
@@ -6,11 +6,6 @@ context('ViewOffenderOverview', () => {
 
   beforeEach(() => fixture.reset())
 
-  it('requires authentication', () => {
-    cy.viewOffender('somecrn')
-    cy.task('getLoginAttempts').should('have.length', 1)
-  })
-
   it('displays offender overview', () => {
     const past = getDateRange('past', { hour: 10, minute: 0 }, { hour: 1 })
     fixture

--- a/cypress/integration/offenders/offender/view-offender.fixture.ts
+++ b/cypress/integration/offenders/offender/view-offender.fixture.ts
@@ -35,7 +35,6 @@ export class ViewOffenderFixture {
   }
 
   whenViewingOffender(): this {
-    cy.login()
     cy.viewOffender(this.crn)
     return this
   }

--- a/cypress/pages/hmpps-auth.page.ts
+++ b/cypress/pages/hmpps-auth.page.ts
@@ -1,0 +1,16 @@
+import { PageBase } from './page'
+
+export class HmppsAuthPage extends PageBase {
+  shouldHaveRedirectedToLoginPage() {
+    this.pageTitle.contains('HMPPS Auth Login')
+  }
+
+  login() {
+    this.shouldHaveRedirectedToLoginPage()
+    cy.get('a').contains('Login').click()
+  }
+
+  shouldHaveRedirectedToLogoutPage() {
+    this.pageTitle.contains('HMPPS Auth Logout')
+  }
+}

--- a/cypress/pages/index.ts
+++ b/cypress/pages/index.ts
@@ -1,2 +1,3 @@
 export * from './home.page'
 export * from './arrange-appointment.page'
+export * from './hmpps-auth.page'

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -13,7 +13,7 @@ const pluginConfig: Cypress.PluginConfig = (on, config) => {
     reset: () => client.reset(),
 
     stubLogin: () =>
-      Promise.all([auth.stubToken(), auth.stubRedirect(), auth.stubLogout(), auth.stubOpenIdConfiguration()]),
+      Promise.all([auth.stubToken(), auth.stubAuthorizeCodeFlow(), auth.stubLogout(), auth.stubOpenIdConfiguration()]),
     stubAuthUser: () => Promise.all([auth.stubUser(), auth.stubUserRoles()]),
   }
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,10 +1,18 @@
-Cypress.Commands.add('login', () => {
-  cy.request('/')
-  cy.task<string>('getLoginUrl').then(x => cy.visit(x))
+import { HmppsAuthPage } from '../pages'
+
+const hmppsAuth = new HmppsAuthPage()
+
+Cypress.Commands.add('home', () => {
+  cy.visit('/')
+  hmppsAuth.login()
 })
 
-Cypress.Commands.add('home', () => cy.visit('/'))
+Cypress.Commands.add('arrangeAppointment', (crn: string) => {
+  cy.visit(`/arrange-appointment/${crn}`)
+  hmppsAuth.login()
+})
 
-Cypress.Commands.add('arrangeAppointment', (crn: string) => cy.visit(`/arrange-appointment/${crn}`))
-
-Cypress.Commands.add('viewOffender', (crn: string) => cy.visit(`/offender/${crn}`))
+Cypress.Commands.add('viewOffender', (crn: string) => {
+  cy.visit(`/offender/${crn}`)
+  hmppsAuth.login()
+})

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -18,6 +18,8 @@ services:
     restart: always
     ports:
       - "9091:8080"
+    command:
+      - -global-response-templating
 
 networks:
   hmpps_int:

--- a/e2e.env
+++ b/e2e.env
@@ -1,4 +1,5 @@
 PORT=3007
+INGRESS_URL=http://localhost:3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 COMMUNITY_API_URL=http://localhost:9091/community


### PR DESCRIPTION
Removes hmpps auth race condition causing intermittent local e2e test failures.
The login assertion is also now part of the request command so I dropped the useless unauthorised user tests.