### PR TITLE
fix: render an unordered list when there's a single item

### DIFF
--- a/src/server/views/_join.njk
+++ b/src/server/views/_join.njk
@@ -12,7 +12,7 @@
 {% endmacro %}
 
 {% macro joinList(items, options) %}
-    {% if options.ordered %}
+    {% if options.ordered and items.length > 1 %}
         <ol class='govuk-list govuk-list--number'>
             {% for item in items %}
                 <li>{{ item }}</li>


### PR DESCRIPTION
Prevents this from happening:

![image](https://user-images.githubusercontent.com/4509102/127116685-8c98d2b9-56f5-44cc-a428-fe185f0c62b8.png)
