### PR TITLE
Use the build number and git_ref args within the base stage, so that …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # Stage: base image
+FROM node:14-buster-slim as base
 ARG BUILD_NUMBER
 ARG GIT_REF
-
-FROM node:14-buster-slim as base
 
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
@@ -22,9 +21,6 @@ RUN npm install -g npm
 
 # Stage: build assets
 FROM base as build
-ARG BUILD_NUMBER
-ARG GIT_REF
-
 COPY . .
 
 RUN npm --version


### PR DESCRIPTION
…the apt-get layer isn't cached