### PR TITLE
use convictionId /eventid in deeplink when it's available

### DIFF
--- a/src/server/offenders/offender/exit/exit.controller.spec.ts
+++ b/src/server/offenders/offender/exit/exit.controller.spec.ts
@@ -77,7 +77,15 @@ describe('ExitController', () => {
       },
     } as DeliusExitViewModel)
   })
+  it('displays delius exit link correctly when no conviction for a crn', async () => {
+    sentenceService.getConvictionId.withArgs('some-crn').resolves(undefined)
 
+    const observed = await subject.getDeliusExit('some-crn')
+
+    expect(observed.links.deliusContactLog).toEqual(
+      'https://delius/NDelius-war/delius/JSP/deeplink.jsp?component=ContactList&offenderId=84520',
+    )
+  })
   it('displays oasys exit', async () => {
     const observed = await subject.getOASysExit('some-crn')
 

--- a/src/server/offenders/offender/exit/exit.controller.ts
+++ b/src/server/offenders/offender/exit/exit.controller.ts
@@ -34,7 +34,7 @@ export class ExitController {
     const contactLog = new URL('/NDelius-war/delius/JSP/deeplink.jsp', this.config.get<DeliusConfig>('delius').baseUrl)
     contactLog.searchParams.set('component', 'ContactList')
     contactLog.searchParams.set('offenderId', offender.offenderId.toString())
-    contactLog.searchParams.set('eventId', convictionId.toString())
+    if (convictionId) contactLog.searchParams.set('eventId', convictionId.toString())
 
     const homePage = new URL('/NDelius-war/delius/JSP/homepage.jsp', this.config.get<DeliusConfig>('delius').baseUrl)
 


### PR DESCRIPTION
Delius page when deeplink is created without conviction id

![image](https://user-images.githubusercontent.com/73168863/133289978-51f96c41-0bf5-4812-958e-88d2f20128ff.png)
