### PR TITLE
Correct the auditing ADR w.r.t. AppInsights

### DIFF
--- a/doc/adr/0012-provide-an-audit-trail-via-logging.md
+++ b/doc/adr/0012-provide-an-audit-trail-via-logging.md
@@ -57,7 +57,9 @@ We will include the [UUID](https://github.com/ministryofjustice/hmpps-auth/blob/
 
 In particular, we need to make sure we log all read operations done through our UI, because they will not be recorded by any other system.
 
-These log messages will be written to application `stdout` and `stderr`, which are [automatically aggregated by Cloud Platform into Azure Application Insights](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/log-collection-and-storage.html#application-log-collection-and-storage), and which are retained there for 13 months. Correlation IDs in AppInsights allow reconstruction of cross-service data for comprehensive audit purposes; we should test that this is working before going live.
+These log messages will be written to application `stdout` and `stderr`, which are [automatically aggregated by Cloud Platform](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/log-collection-and-storage.html#application-log-collection-and-storage).
+
+We will also configure the service to send its logs to Azure AppInsights, which has a retention period of 13 months. Correlation IDs in AppInsights allow reconstruction of cross-service data for comprehensive audit purposes; we should test that this is working before going live.
 
 ## Consequences
 


### PR DESCRIPTION
(from @sldblog's comment https://github.com/ministryofjustice/hmpps-manage-supervisions/pull/169#pullrequestreview-734912509)

Before this change, the ADR implied that logs were sent to AppInsights by default, which isn't the case.