### PR TITLE
Fix empty activity log

### DIFF
--- a/src/server/offenders/offender/activity/activity.service.spec.ts
+++ b/src/server/offenders/offender/activity/activity.service.spec.ts
@@ -175,8 +175,8 @@ describe('ActivityService', () => {
         crn: 'some-crn',
         contactDateFrom: '2019-03-01',
         contactDateTo: '2020-03-02',
-        page: 1,
-        pageSize: 999,
+        page: 0,
+        pageSize: 1000,
         ...expected,
       } as ContactAndAttendanceApiGetOffenderContactSummariesByCrnUsingGETRequest)
     }

--- a/src/server/offenders/offender/activity/activity.service.ts
+++ b/src/server/offenders/offender/activity/activity.service.ts
@@ -21,7 +21,7 @@ import { BreachService } from '../../../community-api/breach'
 import { Mutable } from '../../../@types/mutable'
 import { ActivityLogEntryService } from './activity-log-entry.service'
 
-export const PAGE_SIZE = 999
+export const PAGE_SIZE = 1000
 
 export type GetContactsOptions = Omit<
   ContactAndAttendanceApiGetOffenderContactSummariesByCrnUsingGETRequest,
@@ -49,7 +49,7 @@ export class ActivityService {
     } = await this.community.contactAndAttendance.getOffenderContactSummariesByCrnUsingGET({
       ...resolvedOptions,
       // TODO pagination is disabled
-      page: 1,
+      page: 0,
       pageSize: PAGE_SIZE,
     })
 


### PR DESCRIPTION
Page is zero-based so we were taking the second page. This is unfortunately one of those things that we're vulnerable to due to mocking APIs for test.