### PR TITLE
Update package-lock.json with project name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "hmpps-manage-supervisions",
       "version": "0.0.1",
       "hasInstallScript": true,
       "license": "MIT",


### PR DESCRIPTION
I got this diff after running `npm i`.

System info:

```
$ node -v
v16.9.1
$ npm -v
7.21.1
$ uname -a
Linux arch 5.11.9-arch1-1 #1 SMP PREEMPT Wed, 24 Mar 2021 18:53:54 +0000 x86_64 GNU/Linux
```