### PR TITLE
Add and test for correct page titles on risk pages

### DIFF
--- a/cypress/integration/case/case-risk.spec.ts
+++ b/cypress/integration/case/case-risk.spec.ts
@@ -5,6 +5,7 @@ import { ViewCaseFixture } from './view-case.fixture'
 class Fixture extends ViewCaseFixture {
   shouldRenderRiskDetails(pageTitle: string, assert: (page: CaseRiskDetailPage) => void): this {
     const page = new CaseRiskDetailPage()
+    page.documentTitle.contains(pageTitle)
     page.pageTitle.contains(pageTitle)
     assert(page)
     return this
@@ -12,6 +13,7 @@ class Fixture extends ViewCaseFixture {
 
   shouldRenderRemovedRiskFlagPage(assert: (page: CaseRemovedRisksPage) => void): this {
     const page = new CaseRemovedRisksPage()
+    page.documentTitle.contains('Removed risk flags')
     page.pageTitle.contains('Removed risk flags')
     assert(page)
     return this

--- a/cypress/pages/page.ts
+++ b/cypress/pages/page.ts
@@ -1,4 +1,8 @@
 export abstract class PageBase {
+  get documentTitle() {
+    return cy.get('title')
+  }
+
   get pageTitle() {
     return cy.get('h1')
   }

--- a/src/server/case/risk/registration-detail.njk
+++ b/src/server/case/risk/registration-detail.njk
@@ -1,6 +1,7 @@
 {% extends "partials/layout.njk" %}
 {% from 'components/summary-card.njk' import appSummaryCard %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% set pageTitle = ('Removed risk flag' if registration.removed else 'Risk flag') + ' – ' + registration.text + ' – ' + displayName %}
 
 {% block content %}
 <h1 class="govuk-heading-xl"><span class="govuk-caption-xl">{{ 'Removed risk flag' if registration.removed else 'Risk flag' }}</span> {{ registration.text }}</h1>

--- a/src/server/case/risk/removed-risk-flags.njk
+++ b/src/server/case/risk/removed-risk-flags.njk
@@ -1,4 +1,5 @@
 {% extends "partials/layout.njk" %}
+{% set pageTitle = 'Removed risk flags – ' + displayName %}
 
 {% block content %}
 <h1 class="govuk-heading-xl">Removed risk flags</h1>


### PR DESCRIPTION
Trello: https://trello.com/c/u4p20Y6a/786-design-snagging-add-titles-to-risk-flag-and-removed-risk-flag-pages