### PR TITLE
Allow overriding page titles in case pages

### DIFF
--- a/src/server/case/_layout.njk
+++ b/src/server/case/_layout.njk
@@ -1,14 +1,14 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
 {% extends "partials/layout.njk" %}
-{% set pageTitle = pageName + ' - ' + displayName %}
+{% set pageTitle = pageTitle | default(pageName + ' - ' + displayName) %}
 
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
         <span class="govuk-caption-l"><abbr title="Case reference number">CRN</abbr>: {{ ids.crn }}</span>
         {{ displayName }}
     </h1>
-    
+
     {{ mojSubNavigation({
         attributes: { 'data-qa': 'offender/sub-nav' },
         items: [


### PR DESCRIPTION
Case pages inherit from a customised `case/_layout.njk` file which itself inherits from `partials/layout.njk`. However, they currently do a hard override on the `pageTitle` block which makes it not possible to manually set a different `pageTitle` from inside an individual page like it's possible in the rest of the app.

This changes the override to be a `default()` instead.

Prerequisite to https://trello.com/c/5BACPms1.