### PR TITLE
Update breadcrumbs on activity log filtered pages 

### DIFF
--- a/cypress/integration/case/case-activity.spec.ts
+++ b/cypress/integration/case/case-activity.spec.ts
@@ -104,6 +104,11 @@ class Fixture extends ViewCaseFixture {
     this.page.documentTitle.contains(title)
     return this
   }
+
+  shouldHaveCurrentBreadcrumb(content: string) {
+    this.page.currentBreadcrumb.contains(content)
+    return this
+  }
 }
 
 context('Case activity tab', () => {
@@ -351,6 +356,7 @@ context('Case activity tab', () => {
         .whenClickingSubNavTab('activity')
         .whenClickingFailuresToComplyFilter()
         .shouldHaveDocumentTitle('Failures to comply')
+        .shouldHaveCurrentBreadcrumb('Failures to comply')
         .shouldRenderActivityWithId(2)
         .shouldRenderActivityWithId(4)
         // a complied attended activity not returned by Wiremocked CAPI when the FTC filters are applied
@@ -365,6 +371,7 @@ context('Case activity tab', () => {
         .whenClickingSubNavTab('activity')
         .whenClickingWithoutAnOutcomeFilter()
         .shouldHaveDocumentTitle('Without an outcome')
+        .shouldHaveCurrentBreadcrumb('without an outcome')
         .shouldRenderActivityWithId(5)
         .shouldNotRenderActivityWithId(1)
         .shouldNotRenderActivityWithId(2)

--- a/cypress/integration/case/case-activity.spec.ts
+++ b/cypress/integration/case/case-activity.spec.ts
@@ -370,7 +370,7 @@ context('Case activity tab', () => {
         .whenViewingOffender()
         .whenClickingSubNavTab('activity')
         .whenClickingWithoutAnOutcomeFilter()
-        .shouldHaveDocumentTitle('Without an outcome')
+        .shouldHaveDocumentTitle('without an outcome')
         .shouldHaveCurrentBreadcrumb('without an outcome')
         .shouldRenderActivityWithId(5)
         .shouldNotRenderActivityWithId(1)

--- a/cypress/pages/page.ts
+++ b/cypress/pages/page.ts
@@ -10,4 +10,8 @@ export abstract class PageBase {
   get logoutButton() {
     return cy.get('[data-qa=logout]')
   }
+
+  get currentBreadcrumb() {
+    return cy.get('.govuk-breadcrumbs [aria-current]')
+  }
 }

--- a/src/server/case/activity/activity.controller.spec.ts
+++ b/src/server/case/activity/activity.controller.spec.ts
@@ -144,7 +144,7 @@ describe('ActivityController', () => {
           name: 'Warning letters',
         },
       },
-      title: null,
+      title: undefined,
       currentFilter: undefined,
     })
   })

--- a/src/server/case/activity/activity.controller.spec.ts
+++ b/src/server/case/activity/activity.controller.spec.ts
@@ -124,11 +124,11 @@ describe('ActivityController', () => {
           name: 'Acceptable absences',
         },
         appointments: {
-          description: 'Appointments',
+          description: 'National Standard appointments',
           name: 'Appointments',
         },
         'without-an-outcome': {
-          description: 'Appointments without an outcome',
+          description: 'National Standard appointments without an outcome',
           name: 'Without an outcome',
         },
         'complied-appointments': {
@@ -183,11 +183,11 @@ describe('ActivityController', () => {
           name: 'Acceptable absences',
         },
         appointments: {
-          description: 'Appointments',
+          description: 'National Standard appointments',
           name: 'Appointments',
         },
         'without-an-outcome': {
-          description: 'Appointments without an outcome',
+          description: 'National Standard appointments without an outcome',
           name: 'Without an outcome',
         },
         'complied-appointments': {

--- a/src/server/case/activity/activity.controller.ts
+++ b/src/server/case/activity/activity.controller.ts
@@ -32,6 +32,11 @@ export class ActivityController {
 
   @Get(':filter')
   @Render('case/activity/activity')
+  @Breadcrumb({
+    type: BreadcrumbType.CaseActivityLogWithComplianceFilter,
+    parent: BreadcrumbType.CaseActivityLog,
+    title: options => options.entityName,
+  })
   async getActivityFiltered(
     @Param('crn') crn: string,
     @Param('filter') complianceFilter: ActivityComplianceFilter,
@@ -130,17 +135,23 @@ export class ActivityController {
       this.sentence.getConvictionId(crn),
     ])
     const contacts = await this.activity.getActivityLogPage(crn, offender, { ...options, convictionId })
+    const complianceFilterDescription = options.complianceFilter && FilterLinks[options.complianceFilter].description
 
-    return this.offender.casePageOf<CaseActivityViewModel>(offender, {
-      page: CasePage.Activity,
-      groups: contacts.content,
-      pagination: {
-        page: contacts.number,
-        size: contacts.size,
+    return this.offender.casePageOf<CaseActivityViewModel>(
+      offender,
+      {
+        page: CasePage.Activity,
+        groups: contacts.content,
+        pagination: {
+          page: contacts.number,
+          size: contacts.size,
+        },
+        filters: FilterLinks,
+        currentFilter: options.complianceFilter,
+        title: complianceFilterDescription,
       },
-      filters: FilterLinks,
-      currentFilter: options.complianceFilter,
-      title: options.complianceFilter ? FilterLinks[options.complianceFilter].description : null,
-    })
+      complianceFilterDescription && BreadcrumbType.CaseActivityLogWithComplianceFilter,
+      complianceFilterDescription,
+    )
   }
 }

--- a/src/server/case/activity/activity.njk
+++ b/src/server/case/activity/activity.njk
@@ -1,6 +1,6 @@
 {% extends "../_layout.njk" %}
 {% set pageName = 'Activity log' %}
-{% set pageTitle = (filters[currentFilter].name | default(pageName)) + ' – ' + displayName %}
+{% set pageTitle = (filters[currentFilter].description | default(pageName)) + ' – ' + displayName %}
 {% from 'components/summary-card.njk' import appSummaryCard %}
 
 {% macro flatNotes(notes) -%}

--- a/src/server/case/activity/activity.types.ts
+++ b/src/server/case/activity/activity.types.ts
@@ -96,10 +96,10 @@ export enum ActivityComplianceFilter {
 }
 
 export const FilterLinks: { [key: string]: ActivityFilterMeta } = {
-  [ActivityComplianceFilter.Appointments]: { name: 'Appointments', description: 'Appointments' },
+  [ActivityComplianceFilter.Appointments]: { name: 'Appointments', description: 'National Standard appointments' },
   [ActivityComplianceFilter.WithoutOutcome]: {
     name: 'Without an outcome',
-    description: 'Appointments without an outcome',
+    description: 'National Standard appointments without an outcome',
   },
   [ActivityComplianceFilter.CompliedAppointments]: { name: 'Complied', description: 'Complied appointments' },
   [ActivityComplianceFilter.FailedToComplyAppointments]: {

--- a/src/server/case/offender/offender.service.ts
+++ b/src/server/case/offender/offender.service.ts
@@ -22,10 +22,11 @@ export class OffenderService {
   casePageOf<Model extends CaseViewModel>(
     offender: OffenderDetailSummary,
     partial: Omit<Model, Exclude<keyof CaseViewModelBase<Model['page']>, 'page'>>,
+    breadcrumb = CASE_BREADCRUMBS[partial.page],
+    entityName?: string,
   ): Model {
     const crn = offender.otherIds.crn
-    const links = this.links.of({ crn, offenderName: getDisplayName(offender) })
-    const breadcrumb = CASE_BREADCRUMBS[partial.page]
+    const links = this.links.of({ crn, offenderName: getDisplayName(offender), entityName })
     return {
       ...partial,
       ids: {

--- a/src/server/common/links/links.mock.ts
+++ b/src/server/common/links/links.mock.ts
@@ -12,6 +12,7 @@ class MockLinksService implements ILinksService {
     }
 
     const queryString = Object.entries(options)
+      .filter(([, v]) => v !== undefined)
       .map(([k, v]) => `${k}=${v}`)
       .sort()
       .join('&')

--- a/src/server/common/links/types.ts
+++ b/src/server/common/links/types.ts
@@ -11,6 +11,7 @@ export enum BreadcrumbType {
   CasePreviousConvictions,
   Compliance,
   CaseActivityLog,
+  CaseActivityLogWithComplianceFilter,
   CaseSchedule,
   CaseRisk,
   NewAppointment,


### PR DESCRIPTION
This displays a trailing breadcrumb with the currently active filter, and allows users to return to the unfiltered view by clicking the parent breadcrumb.

Trello: https://trello.com/c/5BACPms1

Depends on: https://github.com/ministryofjustice/hmpps-manage-supervisions/pull/263

![image](https://user-images.githubusercontent.com/1650875/134189451-88269cad-83ad-494d-89f6-55f2cdc73130.png)
