### PR TITLE
Distinguish previous personal circumstances

### DIFF
--- a/cypress/integration/case/case-personal.spec.ts
+++ b/cypress/integration/case/case-personal.spec.ts
@@ -129,6 +129,9 @@ class Fixture extends ViewCaseFixture {
       card.value('Verified').contains(expected.verified ? 'Yes' : 'No')
       card.value('Notes').contains(expected.notes || 'No Notes')
       card.lastUpdated.contains(expected.lastUpdated)
+      if (expected.previous) {
+        card.previousCircumstance.contains('Previous circumstance')
+      }
     })
     return this
   }
@@ -171,6 +174,7 @@ interface ExpectedCircumstance {
   startDate: string
   endDate?: string
   verified: boolean
+  previous: boolean
   notes?: string
   lastUpdated: string
 }
@@ -312,6 +316,7 @@ context('Case personal details tab', () => {
         startDate: '1 April 2005',
         endDate: '2 July 2021',
         verified: true,
+        previous: true,
         notes: 'Divorced',
         lastUpdated: '2 July 2021',
       })

--- a/cypress/pages/case/case-personal-circumstances.page.ts
+++ b/cypress/pages/case/case-personal-circumstances.page.ts
@@ -1,6 +1,10 @@
 import { PageBase } from '../page'
 
 export class PersonalCircumstanceCard {
+  get previousCircumstance() {
+    return cy.get('[data-qa="circumstance-previous"]')
+  }
+
   cell(title: string) {
     return cy.get('dl[data-qa="circumstance-summary"] > div > dt').contains(title)
   }

--- a/src/client/sass/components/_summary-card.scss
+++ b/src/client/sass/components/_summary-card.scss
@@ -17,6 +17,7 @@
   .app-summary-card__title {
     @include govuk-font($size: 19);
     margin: 0;
+    width: 100%;
   }
 
   .app-summary-card__actions {
@@ -87,4 +88,10 @@
     margin-bottom: 0;
     border-bottom: 0;
   }
+}
+
+.app-summary-card__title-with-label {
+  align-items: start;
+  display: flex;
+  justify-content: space-between;
 }

--- a/src/server/case/personal/circumstances.njk
+++ b/src/server/case/personal/circumstances.njk
@@ -14,9 +14,20 @@
 
     {% for circumstance in circumstances %}
         {% set title %}
-            <span class="govuk-!-font-weight-regular govuk-!-font-size-19">{{ circumstance.type }}</span>
-            <br>
-            {{ circumstance.subType }}
+            <div class="app-summary-card__title-with-label">
+                <div>
+                    <span class="govuk-!-font-weight-regular govuk-!-font-size-19">{{ circumstance.type }}</span>
+                    <br>
+                    {{ circumstance.subType }}
+                </div>
+                {% if circumstance.endDate %}
+                    <strong data-qa="circumstance-previous" class="govuk-tag govuk-tag--purple">Previous circumstance
+                        {% if circumstance.previousCircumstanceCount > 1 %}
+                          <span class="govuk-visually-hidden">{{ circumstance.previousCircumstanceCount }}</span>
+                        {% endif %}
+                    </strong>
+                {% endif %}
+            </div>
         {% endset %}
         {% call appSummaryCard({
             titleHtml: title,

--- a/src/server/case/personal/personal.service.spec.ts
+++ b/src/server/case/personal/personal.service.spec.ts
@@ -288,6 +288,7 @@ describe('PersonalService', () => {
         name: 'Relationship: Married / Civil partnership',
         type: 'Relationship',
         subType: 'Married / Civil partnership',
+        previousCircumstanceCount: 0,
         startDate: DateTime.fromObject({ year: 2021, month: 7, day: 8 }),
         endDate: DateTime.fromObject({ year: 2021, month: 7, day: 9 }),
         verified: true,


### PR DESCRIPTION
For circumstances with an end date, we want to display a "Previous circumstance" label in the heading. Additionally, if multiple previous circumstances with the same name are present, we want to differentiate between them with a number.

Trello: https://trello.com/c/5kwym4z7

## After (purple label)

![image](https://user-images.githubusercontent.com/1650875/134324063-0cc3ed36-7181-4599-ad4c-109cab3b9648.png)