### PR TITLE
Fix summary card heading width

### DIFF
--- a/src/client/sass/components/_summary-card.scss
+++ b/src/client/sass/components/_summary-card.scss
@@ -17,7 +17,9 @@
   .app-summary-card__title {
     @include govuk-font($size: 19);
     margin: 0;
-    width: 100%;
+    &:only-child {
+      width: 100%;
+    }
   }
 
   .app-summary-card__actions {


### PR DESCRIPTION
In a previous PR we added `width: 100%` to the h2 in the summary card component in order to allow nesting a right aligned tag inside the h2: https://github.com/ministryofjustice/hmpps-manage-supervisions/pull/266

However, this breaks on the summary cards which contain an `actions` section, which requires that the h2 be left with width auto.  Otherwise, the actions block is squished by the h2.

To resolve this, we can make the h2 have `width: 100%` if it has no siblings.

### Before

![image](https://user-images.githubusercontent.com/1650875/134630478-b4d5b588-d7f2-48e5-a9d5-4aa0614ace4c.png)

### After

![image](https://user-images.githubusercontent.com/1650875/134630556-e1db48c7-0a13-47e2-a4b7-ed113bc4f285.png)
