### PR TITLE
Display error summaries when failing validation

### DIFF
--- a/cypress/integration/appointments/arrange-appointment.spec.ts
+++ b/cypress/integration/appointments/arrange-appointment.spec.ts
@@ -359,6 +359,8 @@ context('Arrange appointment happy path & validation', () => {
   }
 
   function shouldRenderTypeValidationMessages(expected: { type?: string; other?: string }) {
+    page.documentTitle.contains('Error')
+    page.errorSummary.contains('There is a problem')
     for (const name of Object.keys(page.type.errorMessages)) {
       if (expected[name]) {
         page.type.errorMessages[name].contains(expected[name])
@@ -369,6 +371,8 @@ context('Arrange appointment happy path & validation', () => {
   }
 
   function shouldRenderLocationValidationMessages(expected: string) {
+    page.documentTitle.contains('Error')
+    page.errorSummary.contains('There is a problem')
     page.where.errorMessages.location.contains(expected)
   }
 

--- a/cypress/pages/arrange-appointment.page.ts
+++ b/cypress/pages/arrange-appointment.page.ts
@@ -217,4 +217,8 @@ export class ArrangeAppointmentPage extends PageBase {
       },
     }
   }
+
+  get errorSummary() {
+    return cy.get('#error-summary-title')
+  }
 }

--- a/src/server/bootstrap/nunjucks/filters/validation.ts
+++ b/src/server/bootstrap/nunjucks/filters/validation.ts
@@ -1,9 +1,21 @@
 import { NunjucksFilter } from './types'
 import { ValidationError } from 'class-validator'
-import { flattenValidationErrors } from '../../../util/flattenValidationErrors'
+import { flattenValidationErrors, FlatValidationError } from '../../../util/flattenValidationErrors'
 
 export interface GdsErrorMessage {
   text: string
+  href?: string
+}
+
+export class ErrorSummary implements NunjucksFilter {
+  filter(errors: ValidationError[]): GdsErrorMessage[] {
+    return flattenValidationErrors(errors || []).map(
+      (error: FlatValidationError): GdsErrorMessage => ({
+        text: [...new Set(Object.values(error.constraints))].join(', '),
+        href: `#${error.path}`,
+      }),
+    )
+  }
 }
 
 export class FindErrorMessages implements NunjucksFilter {

--- a/src/server/views/pages/wizard-form.njk
+++ b/src/server/views/pages/wizard-form.njk
@@ -1,5 +1,7 @@
 {% extends "../partials/layout.njk" %}
-{% block pageTitle %}{{ title }}{% endblock %}
+{% block pageTitle %}
+  {% if errors.length > 0 %}Error: {% endif %}{{ title }}
+{% endblock %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -8,6 +10,13 @@
 {% endblock %}
 
 {% block content %}
+  {% if errors.length > 0 %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors | errorSummary
+    }) }}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="post" autocomplete="off" action="{{ action if action else paths.current }}">


### PR DESCRIPTION
During the arrange appointment steps, if a user fails validation, we should display a standard `govukErrorSummary` component at the top of the page, which links to each error message in turn. We should also auto-focus this area and prefix the title of the page with `Error: `.

The auto-focusing is automatically done by importing the GOVUK Design System JS, so this PR implements the rest by adding the component to the `wizard-form.njk` shared layout, and implementing a filter to generate the appropriate `href`s.

A bug with this is that it doesn't work for every single error (date fields are busted), but fixing those will come in a follow-up PR. This already does enough.

Trello: https://trello.com/c/704h2ArE

Follow-up: https://trello.com/c/LcBxIsU1

## After

![image](https://user-images.githubusercontent.com/1650875/135113883-73a38206-9747-4d70-8e45-6939dddf521b.png)
