### PR TITLE
Update change link hidden text

### DIFF
--- a/src/server/arrange-appointment/views/partials/session-details.njk
+++ b/src/server/arrange-appointment/views/partials/session-details.njk
@@ -46,7 +46,7 @@
             {
               href: paths.when,
               text: "Change",
-              visuallyHiddenText: "date",
+              visuallyHiddenText: "time",
               classes: ["qa-change"]
             }
           ]

--- a/src/server/case/activity/appointment.njk
+++ b/src/server/case/activity/appointment.njk
@@ -44,7 +44,7 @@
             {
                 key: { text: "Appointment notes" },
                 value: { html: (appointment.notes | nl2br) if appointment.notes else 'No notes' },
-                actions: { items: [{ href: appointment.links.updateOutcome, text: "Change" }] }
+                actions: { items: [{ href: appointment.links.updateOutcome, html: "Change<span class=\"govuk-visually-hidden\"> appointment notes</span>" }] }
             } if not appointment.outcome,
             {
                 key: { text: "Sensitive" },


### PR DESCRIPTION
The change link for time should read `Change time` on the check your answers page.

The change link for appointment notes should read `Change appointment notes` on the appointment details page.