### PR TITLE
Fix design snags: grey app-hint-s text and en dash

### DIFF
--- a/cypress/integration/case/case-personal.spec.ts
+++ b/cypress/integration/case/case-personal.spec.ts
@@ -252,7 +252,7 @@ context('Case personal details tab', () => {
       .whenClickingViewAllAddresses()
       .shouldBeAccessible()
       .shouldRenderAddress('main', {
-        name: 'Main address - Since 16 July 2015',
+        name: 'Main address – Since 16 July 2015',
         status: 'Main address',
         address: '1 High Street Sheffield South Yorkshire S10 1AG',
         phone: '0123456789',
@@ -261,13 +261,13 @@ context('Case personal details tab', () => {
         notes: 'Sleeping on sofa',
       })
       .shouldRenderAddress('other', {
-        name: 'Secondary address - Since 8 January 2016',
+        name: 'Secondary address – Since 8 January 2016',
         status: 'Secondary address',
         address: '24 The Mill Sherbourne Street Birmingham West Midlands B16 8TP',
         startDate: '8 January 2016',
       })
       .shouldRenderAddress('previous', {
-        name: 'Main address - 16 July 2001 to 16 July 2015',
+        name: 'Main address – 16 July 2001 to 16 July 2015',
         status: 'Main address',
         address: 'No fixed abode Tent',
         type: 'Tent (not verified)',

--- a/src/client/sass/local.scss
+++ b/src/client/sass/local.scss
@@ -31,3 +31,7 @@ table.app-table--cell-vertical-align-bottom {
   position: relative;
   top: 3px;
 }
+
+.app-hint-s {
+  color: govuk-colour("dark-grey");
+}

--- a/src/server/arrange-appointment/views/when.njk
+++ b/src/server/arrange-appointment/views/when.njk
@@ -9,15 +9,15 @@
   {% set circumstancesHTML %}
     <p class="govuk-body">
       <strong>Preferred language</strong><br>
-      <span data-qa="arrange-appointment/where/language">{{ offender.personalCircumstances.language  | default('<span class="govuk-hint-s">Not known</span>', true) | safe}}</span>
+      <span data-qa="arrange-appointment/where/language">{{ offender.personalCircumstances.language  | default('<span class="app-hint-s">Not known</span>', true) | safe}}</span>
     </p>
     <p class="govuk-body">
       <strong>Disabilities</strong><br>
-      <span data-qa="arrange-appointment/where/disabilities">{{ offender.personalCircumstances.disabilities | default('<span class="govuk-hint-s">None known</span>', true) | safe }}</span>
+      <span data-qa="arrange-appointment/where/disabilities">{{ offender.personalCircumstances.disabilities | default('<span class="app-hint-s">None known</span>', true) | safe }}</span>
     </p>
     <p class="govuk-body">
       <strong>Employment status</strong><br>
-      <span data-qa="arrange-appointment/where/employment">{{ offender.personalCircumstances.employment | default('<span class="govuk-hint-s">Not known</span>', true) | safe}}</span>
+      <span data-qa="arrange-appointment/where/employment">{{ offender.personalCircumstances.employment | default('<span class="app-hint-s">Not known</span>', true) | safe}}</span>
     </p>
   {% endset %}
 

--- a/src/server/case/activity/communication.njk
+++ b/src/server/case/activity/communication.njk
@@ -37,7 +37,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body-s govuk-hint-s" data-qa='contact-last-updated'>
+            <p class="govuk-body-s app-hint-s" data-qa='contact-last-updated'>
                 Last updated by {{ contact.lastUpdatedBy }}
                 on {{ contact.lastUpdatedDateTime | longDate }}
                 at {{ contact.lastUpdatedDateTime | time }}

--- a/src/server/case/activity/other.njk
+++ b/src/server/case/activity/other.njk
@@ -25,7 +25,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body-s govuk-hint-s" data-qa='contact-last-updated'>
+            <p class="govuk-body-s app-hint-s" data-qa='contact-last-updated'>
                 Last updated by {{ contact.lastUpdatedBy }}
                 on {{ contact.lastUpdatedDateTime | longDate }}
                 at {{ contact.lastUpdatedDateTime | time }}

--- a/src/server/case/personal/circumstances.njk
+++ b/src/server/case/personal/circumstances.njk
@@ -66,7 +66,7 @@
                     }
                 ]
             }) }}
-            <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-4 govuk-body-s govuk-hint-s" data-qa='circumstance-last-updated'>
+            <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-4 govuk-body-s app-hint-s" data-qa='circumstance-last-updated'>
                 Last updated {{ circumstance.lastUpdated | shortDate }}
             </p>
         {%- endcall %}

--- a/src/server/case/personal/personal.service.spec.ts
+++ b/src/server/case/personal/personal.service.spec.ts
@@ -89,7 +89,7 @@ describe('PersonalService', () => {
   })
 
   const expectedMainAddress: AddressDetail = {
-    name: 'Main address - Since 1 January 2021',
+    name: 'Main address – Since 1 January 2021',
     lines: ['123 Some building Some street', 'Some town', 'Some county', 'Some postcode'],
     phone: '9876543210',
     type: 'Approved premises (verified)',

--- a/src/server/case/personal/personal.service.ts
+++ b/src/server/case/personal/personal.service.ts
@@ -47,7 +47,7 @@ function getAddressViewModel(address: Address): AddressDetail {
     ? [startDate, endDate].map(x => x.toFormat('d MMMM yyyy')).join(' to ')
     : `Since ${startDate.toFormat('d MMMM yyyy')}`
   return {
-    name: `${status} - ${dateRange}`,
+    name: `${status} – ${dateRange}`,
     // addresses with an end date in the past are previous addresses
     // but previous addresses can also be classified by status regardless of end date...
     active:


### PR DESCRIPTION
`govuk-hint-s` was copied from the prototype without the CSS. The naming of the class is wrong however, because it's a custom CSS class that doesn't exist in the design system. As such, I've renamed it to `app-hint-s`.

Also use en dash for status and date ranges on address pages.