### PR TITLE
Fix open strong tags in header

### DIFF
--- a/src/server/views/partials/header.njk
+++ b/src/server/views/partials/header.njk
@@ -33,7 +33,7 @@
   <div class="moj-primary-navigation">
     <div class="moj-primary-navigation__container">
       <div class="app-organisation-nav-title">
-        <span class="govuk-body-s"><strong><strong></span>
+        <span class="govuk-body-s"><strong></strong></span>
       </div>
       <div class="moj-primary-navigation__nav">
         <nav class="moj-primary-navigation" aria-label="Primary navigation">


### PR DESCRIPTION
Previously introduced in https://github.com/ministryofjustice/hmpps-manage-supervisions/pull/293,
this tag is meant to wrap an organisation name.

It is not meant to wrap the entire application with *DOUBLE STRENGTH*.