### PR TITLE
Fix odd looking line breaks in activity cards

### DIFF
--- a/src/server/case/activity/activity.njk
+++ b/src/server/case/activity/activity.njk
@@ -35,7 +35,7 @@
     {% set title %}
         <span class="govuk-heading-s govuk-!-margin-bottom-0">
             <a href="{{ entry.links.view }}">{{ entry.name }}</a>
-            <span class="govuk-!-font-weight-regular">at {{ entry.start | time }}</span>
+            <span class="govuk-!-font-weight-regular">at&nbsp;{{ entry.start | time }}</span>
         </span>
         <span class='govuk-!-font-size-16' data-qa='sub-title'>
             {% if entry.nationalStandard %}
@@ -50,7 +50,7 @@
         classes: 'govuk-!-margin-bottom-2',
         attributes: { 'data-qa': 'offender/activity/' + entry.id },
         actions: { items: [{ href: entry.links.recordMissingAttendance, text: "Record an outcome" }] } if not entry.outcome,
-        actionsHtml: govukTag({ text: entry.outcome.tag.name, classes: entry.outcome.tag.colour | tagClassName }) if entry.outcome,
+        actionsHtml: govukTag({ text: entry.outcome.tag.name, classes: entry.outcome.tag.colour | tagClassName + ' govuk-!-margin-left-2' }) if entry.outcome,
         headingLevel: 4
     }) -%}
         {% if entry.rarActivity or entry.enforcementAction %}
@@ -71,7 +71,7 @@
     {% set title %}
         <a href="{{ entry.links.view }}">{{ entry.name }}</a>
         {% if options.time %}
-            <span class="govuk-!-font-weight-regular">at {{ entry.start | time }}</span>
+            <span class="govuk-!-font-weight-regular">at&nbsp;{{ entry.start | time }}</span>
         {% endif %}
     {% endset %}
     {% call appSummaryCard({


### PR DESCRIPTION
The `at 12pm` text should wrap together, and the tag can benefit from a bit of extra whitespace on the left to enforce a clearer separation.

## Before

![image](https://user-images.githubusercontent.com/1650875/136533914-0eeac48c-d200-404d-ab2a-59a869d80c86.png)
![image](https://user-images.githubusercontent.com/1650875/136534186-e8803eee-a090-4e40-899d-d9428374661f.png)


## After

![image](https://user-images.githubusercontent.com/1650875/136533975-48c7fd1b-9c26-4106-9101-9b4dd2b75670.png)
![image](https://user-images.githubusercontent.com/1650875/136534230-4dbf2fca-f570-4a56-a838-70872c530dba.png)

