### PR TITLE
Display all previous orders and breaches in overview

### DIFF
--- a/cypress/plugins/convictions.ts
+++ b/cypress/plugins/convictions.ts
@@ -4,7 +4,7 @@ import { SeedFn } from './wiremock'
 import { DeepPartial } from '../../src/server/app.types'
 
 export const ACTIVE_CONVICTION_ID = 100
-export const PREVIOUS_CONVICTION_IDS = [101]
+export const PREVIOUS_CONVICTION_IDS = [101, 102]
 
 export const ACTIVE_CONVICTION: DeepPartial<Conviction> = {
   convictionId: ACTIVE_CONVICTION_ID,
@@ -82,6 +82,23 @@ export const PREVIOUS_CONVICTIONS: DeepPartial<Conviction>[] = [
       legacyOrder: false,
     },
     offences: [{ mainOffence: true, offenceCount: 2, detail: { subCategoryDescription: 'Assault on Police Officer' } }],
+  },
+  {
+    convictionId: PREVIOUS_CONVICTION_IDS[1],
+    active: false,
+    convictionDate: '2016-11-01',
+    sentence: {
+      sentenceType: {
+        description: 'ORA Community Order',
+      },
+      startDate: '2016-12-01',
+      terminationDate: '2018-12-01',
+      originalLength: 24,
+      originalLengthUnits: 'Months',
+      cja2003Order: true,
+      legacyOrder: false,
+    },
+    offences: [{ mainOffence: true, offenceCount: 1, detail: { subCategoryDescription: 'Drinking and Driving' } }],
   },
 ]
 

--- a/src/server/case/compliance/compliance.controller.ts
+++ b/src/server/case/compliance/compliance.controller.ts
@@ -4,6 +4,7 @@ import { CaseTabbedPage } from '../case-tabbed-page.decorators'
 import { OffenderService } from '../offender'
 import { SentenceService } from '../sentence'
 import { BreadcrumbType, UtmMedium } from '../../common/links'
+import { DateTime } from 'luxon'
 
 @Controller('case/:crn(\\w+)/compliance')
 export class ComplianceController {
@@ -13,9 +14,12 @@ export class ComplianceController {
   @Render('case/compliance/compliance')
   @CaseTabbedPage({ page: CasePage.Compliance, title: 'Compliance' })
   async getCompliance(@Param('crn') crn: string): Promise<CaseComplianceViewModel> {
+    const complianceFrom = DateTime.now()
+      .minus({ years: 2 })
+      .set({ day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 })
     const [offender, compliance] = await Promise.all([
       this.offender.getOffenderSummary(crn),
-      this.sentence.getSentenceComplianceDetails(crn),
+      this.sentence.getSentenceComplianceDetails(crn, complianceFrom),
     ])
 
     return this.offender.casePageOf<CaseComplianceViewModel>(offender, {

--- a/src/server/case/sentence/sentence.service.spec.ts
+++ b/src/server/case/sentence/sentence.service.spec.ts
@@ -310,7 +310,8 @@ describe('SentenceService', () => {
         currentSummary.lastRecentBreachEnd,
       )
 
-      const observed = await subject.getSentenceComplianceDetails('some-crn')
+      const from = DateTime.now().minus({ years: 2 }).set({ day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 })
+      const observed = await subject.getSentenceComplianceDetails('some-crn', from)
 
       expect(observed).toEqual({
         current: {

--- a/src/server/case/sentence/sentence.service.ts
+++ b/src/server/case/sentence/sentence.service.ts
@@ -116,8 +116,7 @@ export class SentenceService {
     }
   }
 
-  async getSentenceComplianceDetails(crn: string): Promise<ComplianceDetails> {
-    const from = DateTime.now().minus({ years: 2 }).set({ day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 })
+  async getSentenceComplianceDetails(crn: string, from?: DateTime): Promise<ComplianceDetails> {
     const { requirements, current, previous } = await this.getConvictionsAndRequirements(crn, from)
 
     const [currentSummary, ...previousSummaries] = await Promise.all([

--- a/src/server/case/sentence/sentence.types.ts
+++ b/src/server/case/sentence/sentence.types.ts
@@ -124,7 +124,7 @@ export interface ComplianceDetails {
   current?: CurrentComplianceConvictionSummary
   previous: {
     convictions: ComplianceConvictionSummary[]
-    dateFrom: DateTime
+    dateFrom?: DateTime
     totalBreaches: number
   }
 }


### PR DESCRIPTION
The page previously used a filtered list that only included the ones that happened in the last 24 months. This makes it consistent with the information on the Sentence page.