### PR TITLE
Rewrite other disabilities in frontend on disabilities page

### DIFF
--- a/cypress/integration/case/case-overview.spec.ts
+++ b/cypress/integration/case/case-overview.spec.ts
@@ -90,7 +90,8 @@ context('Case overview tab', () => {
             .contains(
               [
                 'Employment: Temporary/casual work (30 or more hours per week)',
-                'Learning Difficulties: Other',
+                'Learning Difficulties: With adjustment',
+                'Other disability: With adjustment',
                 'Speech Impairment: No adjustments',
               ].join(' '),
             )

--- a/cypress/integration/case/case-personal.spec.ts
+++ b/cypress/integration/case/case-personal.spec.ts
@@ -223,7 +223,9 @@ context('Case personal details tab', () => {
             card.title('Current circumstances').contains('Last updated')
             card
               .value('Disabilities and adjustments')
-              .contains('Learning Difficulties: Other Speech Impairment: No adjustments')
+              .contains(
+                'Learning Difficulties: With adjustment Other disability: With adjustment Speech Impairment: No adjustments',
+              )
             card.title('Disabilities and adjustments').contains('Last updated')
             card.value('Criminogenic needs').contains('Accommodation Alcohol Misuse Drug Misuse')
             card.valueAbbr('CRN').contains(fixture.data.crn)

--- a/cypress/plugins/offender.ts
+++ b/cypress/plugins/offender.ts
@@ -102,6 +102,19 @@ export const OFFENDER: DeepPartial<OffenderDetail> = {
     sexualOrientation: 'Bisexual',
     disabilities: [
       {
+        disabilityType: { description: 'Other' },
+        startDate: '2021-02-01',
+        notes: null,
+        provisions: [
+          {
+            startDate: '2021-05-10',
+            provisionType: { description: 'Other' },
+            notes: 'Other',
+          },
+        ],
+        lastUpdatedDateTime: '2021-09-01',
+      },
+      {
         disabilityType: { description: 'Learning Difficulties' },
         startDate: '2021-02-01',
         notes: null,


### PR DESCRIPTION
We currently display things like `Other: Other` in situations where the disability type description and the provision are provided as such from upstream, `community-api` or Delius.

This patches these strings on the frontend so that they display in a more user friendly way.

### After

![image](https://user-images.githubusercontent.com/1650875/139224746-99c450d2-b940-4330-a56d-849bed3b765d.png)
