### PR TITLE
Improve the way risks display

### DIFF
--- a/cypress/integration/case/case-overview.spec.ts
+++ b/cypress/integration/case/case-overview.spec.ts
@@ -98,7 +98,7 @@ context('Case overview tab', () => {
 
         page.risk(card => {
           card.value('Risk of serious harm (ROSH) in the community').contains('Very high risk of serious harm')
-          card.value('Risk of serious harm to themselves').contains('Current concerns')
+          card.value('Risk of serious harm to themselves').contains('Immediate concerns')
           card.value('Risk flags').contains('Restraining Order')
         })
 

--- a/cypress/integration/case/case-risk.spec.ts
+++ b/cypress/integration/case/case-risk.spec.ts
@@ -73,7 +73,7 @@ context('Case risk tab', () => {
                 () => {
                   page.currentNotes.contains('No detail given')
                   page.previousNotes.contains(
-                    'Soluta tempore nemo et velit est perspiciatis. Neque error aut est nemo quasi. Et labore impedit omnis numquam id et eaque facere itaque. Ipsam et atque eos tempora possimus.',
+                    'Soluta tempore nemo et velit est perspiciatis. Neque error aut est nemo quasi. Et labore impedit omnis numquam id et eaque facere itaque. Ipsam et atque eos tempora possimus. A hostel setting would pose significant risk for this case.',
                   )
                 },
               )

--- a/cypress/integration/case/case-risk.spec.ts
+++ b/cypress/integration/case/case-risk.spec.ts
@@ -66,10 +66,10 @@ context('Case risk tab', () => {
 
           page.roshThemselves(card =>
             card.summaryList(list => {
-              list.value('Risk of suicide or self harm').contains('There are concerns about self-harm and suicide')
+              list.value('Risk of suicide or self-harm').contains('Immediate concerns about suicide and self-harm')
               list.details(
                 'Coping in custody or a hostel',
-                'There were concerns about coping in a hostel and in custody',
+                'Previous concerns about coping in custody and in a hostel',
                 () => {
                   page.currentNotes.contains('No detail given')
                   page.previousNotes.contains(

--- a/cypress/plugins/risks.ts
+++ b/cypress/plugins/risks.ts
@@ -30,7 +30,7 @@ export const RISKS: DeepPartial<AllRoshRiskDtoAllRisksView> = {
     },
     hostelSetting: {
       previous: RiskDtoAllRisksViewPrevious.Yes,
-      previousConcernsText: null,
+      previousConcernsText: 'A hostel setting would pose significant risk for this case.',
       current: RiskDtoAllRisksViewCurrent.No,
       currentConcernsText: null,
     },

--- a/src/server/case/overview.njk
+++ b/src/server/case/overview.njk
@@ -77,12 +77,28 @@
                 }) if risks.community.level else 'No concerns' }}
             {% endset %}
             {% set roshToThemselves %}
-                {% if risks.self.current %}
-                    Current concerns
-                {% elseif risks.self.previous %}
-                    Previous concerns
-                {% else %}
-                    No concerns
+                {% if risks.self.current.length === 1 %}
+                    <p>Immediate concerns about {{ risks.self.current[0] }}</p>
+                {% elif risks.self.current.length > 1 %}
+                    <p>Immediate concerns about:</p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        {% for concern in risks.self.current %}
+                          <li>{{ concern }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                {% if risks.self.previous.length === 1 %}
+                    <p>Previous concerns about {{ risks.self.previous[0] }}</p>
+                {% elif risks.self.current.length > 1 %}
+                    <p>Previous concerns about:</p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        {% for concern in risks.self.previous %}
+                          <li>{{ concern }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                {% if risks.self.current.length === 0 and risks.self.previous.length === 0 %}
+                    <p>No concerns</p>
                 {% endif %}
             {% endset %}
         {% case 'unavailable' %}
@@ -103,7 +119,7 @@
                 },
                 {
                     key: { text: 'Risk of serious harm to themselves' },
-                    value: { text: roshToThemselves }
+                    value: { html: roshToThemselves }
                 },
                 {
                     key: { text: 'Risk flags' },

--- a/src/server/case/overview.njk
+++ b/src/server/case/overview.njk
@@ -111,14 +111,20 @@
             {% endset %}
         {% endswitch %}
 
+        {% set lastUpdatedAt %}
+            {% if risks.assessedOn %}
+                <br><span class="govuk-!-font-size-16 govuk-!-font-weight-regular">Last updated {{ risks.assessedOn | shortDate }}</span>
+            {% endif %}
+        {% endset %}
+
         {{ govukSummaryList({
             rows: [
                 {
-                    key: { text: 'Risk of serious harm (ROSH) in the community' },
+                    key: { html: 'Risk of serious harm (ROSH) in the community' + lastUpdatedAt },
                     value: { html: roshInCommunity }
                 },
                 {
-                    key: { text: 'Risk of serious harm to themselves' },
+                    key: { html: 'Risk of serious harm to themselves' + lastUpdatedAt },
                     value: { html: roshToThemselves }
                 },
                 {

--- a/src/server/case/risk/risk.fake.ts
+++ b/src/server/case/risk/risk.fake.ts
@@ -87,8 +87,8 @@ export const fakeRisks = fake<Risks>((options, partial = {}) => ({
     whoIsAtRisk: faker.lorem.sentence(),
   },
   self: {
-    current: faker.datatype.boolean(),
-    previous: faker.datatype.boolean(),
+    current: ['suicide'],
+    previous: [],
     harm: fakeFlatRiskToSelf(),
     custody: fakeFlatRiskToSelf(),
     vulnerability: fakeFlatRiskToSelf(),

--- a/src/server/case/risk/risk.njk
+++ b/src/server/case/risk/risk.njk
@@ -6,7 +6,7 @@
 {% macro roshDetail(risk) %}
     {% if not risk.value %}
         No concerns
-    {% elseif risk.notes.current or risk.notes.previous %}
+    {% else %}
         {% set detailsHtml %}
             <h3 class="govuk-heading-s">Current circumstances, issues and needs</h3>
             <p class='govuk-body' data-qa='offender/risk/current-notes'>
@@ -19,8 +19,6 @@
             </p>
         {% endset %}
         {{ govukDetails({ summaryText: risk.value, html: detailsHtml }) }}
-    {% else %}
-        {{ risk.value }}
     {% endif %}
 {% endmacro %}
 

--- a/src/server/case/risk/risk.njk
+++ b/src/server/case/risk/risk.njk
@@ -88,7 +88,7 @@
             {{ govukSummaryList({
                 rows: [
                     {
-                        key: { text: "Risk of suicide or self harm" },
+                        key: { text: "Risk of suicide or self-harm" },
                         value: { html: roshDetail(risks.self.harm) }
                     },
                     {

--- a/src/server/case/risk/risk.njk
+++ b/src/server/case/risk/risk.njk
@@ -74,6 +74,12 @@
                     }
                 ]
             }) }}
+
+            {% if risks.assessedOn %}
+                <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-4 govuk-body-s app-hint-s">
+                    OASys assessment completed on {{ risks.assessedOn | shortDate }}
+                </p>
+            {% endif %}
         {%- endcall %}
 
         {% call appSummaryCard({
@@ -97,6 +103,12 @@
                     }
                 ]
             }) }}
+
+            {% if risks.assessedOn %}
+                <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-4 govuk-body-s app-hint-s">
+                    OASys assessment completed on {{ risks.assessedOn | shortDate }}
+                </p>
+            {% endif %}
         {%- endcall %}
     {% elseif risks.status === 'missing' %}
         {% set noRisksWarning %}

--- a/src/server/case/risk/risk.service.spec.ts
+++ b/src/server/case/risk/risk.service.spec.ts
@@ -139,19 +139,19 @@ describe('RiskService', () => {
         },
         self: {
           harm: {
-            notes: { current: 'Some current concerns', previous: null },
-            value: 'There are concerns about self-harm and suicide',
+            notes: { current: 'Some ignored current concerns', previous: null },
+            value: 'Immediate concerns about suicide and self-harm',
           },
           custody: {
             notes: { current: null, previous: 'Some previous concerns' },
-            value: 'There were concerns about coping in custody',
+            value: 'Previous concerns about coping in custody',
           },
           vulnerability: {
             notes: { current: null, previous: null },
             value: null,
           },
-          current: true,
-          previous: true,
+          current: ['suicide', 'self-harm'],
+          previous: ['coping in custody'],
         },
         assessedOn: DateTime.fromISO('2000-01-02T13:30:00'),
       } as Risks)
@@ -195,8 +195,8 @@ describe('RiskService', () => {
           custody: { notes: { current: null, previous: null }, value: null },
           harm: { notes: { current: null, previous: null }, value: null },
           vulnerability: { notes: { current: null, previous: null }, value: null },
-          current: false,
-          previous: false,
+          current: [],
+          previous: [],
         },
         assessedOn: null,
       } as Risks)

--- a/src/server/case/risk/risk.service.spec.ts
+++ b/src/server/case/risk/risk.service.spec.ts
@@ -139,7 +139,7 @@ describe('RiskService', () => {
         },
         self: {
           harm: {
-            notes: { current: 'Some ignored current concerns', previous: null },
+            notes: { current: 'Some current concerns\n\nSome ignored current concerns', previous: null },
             value: 'Immediate concerns about suicide and self-harm',
           },
           custody: {

--- a/src/server/case/risk/risk.service.ts
+++ b/src/server/case/risk/risk.service.ts
@@ -261,12 +261,15 @@ function flattenRisks(
 
     if (risk.current === RiskDtoCurrent.Yes) {
       currentConcerns.push(name)
-      result.notes.current = risk.currentConcernsText
+      if (result.notes.current && risk.currentConcernsText) result.notes.current += '\n\n' + risk.currentConcernsText
+      else result.notes.current = risk.currentConcernsText
     }
 
     if (risk.previous === RiskDtoPrevious.Yes) {
       previousConcerns.push(name)
-      result.notes.previous = risk.previousConcernsText
+      if (result.notes.previous && risk.previousConcernsText)
+        result.notes.previous += '\n\n' + risk.previousConcernsText
+      else result.notes.previous = risk.previousConcernsText
     }
   }
 

--- a/src/server/case/risk/risk.service.ts
+++ b/src/server/case/risk/risk.service.ts
@@ -222,7 +222,7 @@ function getSummaryRisks(riskToSelf: RoshRiskToSelfDtoAllRisksView): { current: 
   const formatConcern = concern =>
     ({
       suicide: 'suicide',
-      selfHarm: 'self harm',
+      selfHarm: 'self-harm',
       custody: 'coping in custody',
       hostelSetting: 'coping in a hostel setting',
       vulnerability: 'a vulnerability',

--- a/src/server/case/risk/risk.service.ts
+++ b/src/server/case/risk/risk.service.ts
@@ -73,8 +73,8 @@ export class RiskService {
           },
           self: {
             ...getSummaryRisks(riskToSelf),
-            harm: flattenRisks({ selfHarm: 'self-harm', suicide: 'suicide' }, riskToSelf),
-            custody: flattenRisks({ hostelSetting: 'in a hostel', custody: 'in custody' }, riskToSelf, 'about coping'),
+            harm: flattenRisks({ suicide: 'suicide', selfHarm: 'self-harm' }, riskToSelf),
+            custody: flattenRisks({ custody: 'in custody', hostelSetting: 'in a hostel' }, riskToSelf, 'about coping'),
             vulnerability: flattenRisks({ vulnerability: 'a vulnerability' }, riskToSelf),
           },
           assessedOn: assessedOn ? DateTime.fromISO(assessedOn) : null,
@@ -274,13 +274,13 @@ function flattenRisks(
     result.value = null
   } else if (previousConcerns.length === 0 || currentConcerns.length === Object.keys(meta).length) {
     // no previous or all current then ignore previous
-    result.value = `There are concerns ${about} ${toList(currentConcerns)}`
+    result.value = `Immediate concerns ${about} ${toList(currentConcerns)}`
   } else if (currentConcerns.length === 0) {
     // no current, just previous
-    result.value = `There were concerns ${about} ${toList(previousConcerns)}`
+    result.value = `Previous concerns ${about} ${toList(previousConcerns)}`
   } else {
     // current & previous
-    result.value = `There are concerns ${about} ${toList(currentConcerns)} and previous concerns ${about} ${toList(
+    result.value = `Immediate concerns ${about} ${toList(currentConcerns)} and previous concerns ${about} ${toList(
       previousConcerns,
     )}`
   }

--- a/src/server/case/risk/risk.service.ts
+++ b/src/server/case/risk/risk.service.ts
@@ -215,20 +215,27 @@ export class RiskService {
   }
 }
 
-function getSummaryRisks(riskToSelf: RoshRiskToSelfDtoAllRisksView): { current: boolean; previous: boolean } {
-  return Object.values(riskToSelf || {})
-    .filter(x => x)
-    .map(({ current, previous }) => ({
-      current: current === RiskDtoCurrent.Yes,
-      previous: previous === RiskDtoPrevious.Yes,
-    }))
-    .reduce(
-      (x, y) => ({
-        current: x.current || y.current,
-        previous: x.previous || y.previous,
-      }),
-      { current: false, previous: false },
-    )
+function getSummaryRisks(riskToSelf: RoshRiskToSelfDtoAllRisksView): { current: string[]; previous: string[] } {
+  if (!riskToSelf) {
+    return { current: [], previous: [] }
+  }
+  const formatConcern = concern =>
+    ({
+      suicide: 'suicide',
+      selfHarm: 'self harm',
+      custody: 'coping in custody',
+      hostelSetting: 'coping in a hostel setting',
+      vulnerability: 'a vulnerability',
+    }[concern])
+  const concerns = Object.keys(riskToSelf)
+  const current = concerns.filter(key => riskToSelf[key].current === RiskDtoCurrent.Yes)
+  const previous = concerns
+    .filter(key => riskToSelf[key].previous === RiskDtoPrevious.Yes)
+    .filter(concern => current.indexOf(concern) === -1)
+  return {
+    current: current.map(formatConcern),
+    previous: previous.map(formatConcern),
+  }
 }
 
 function flattenRisks(

--- a/src/server/case/risk/risk.types.ts
+++ b/src/server/case/risk/risk.types.ts
@@ -28,8 +28,8 @@ export interface Risks extends RisksAndNeedsResult<AssessRisksAndNeedsApiStatus.
     riskImminence?: string
   }
   self: {
-    current: boolean
-    previous: boolean
+    current: string[]
+    previous: string[]
     harm: FlatRiskToSelf
     custody: FlatRiskToSelf
     vulnerability: FlatRiskToSelf


### PR DESCRIPTION
Follow the latest guidance on the design history, by displaying more information about current and past concerns in the risks section of the Overview page.

On the risks page, update the details element summary, and always display current or previous circumstances.

Display timestamps in the overview and risks tab.

https://ms-design-history.herokuapp.com/risk-to-themselves-iteration/

### After

![image](https://user-images.githubusercontent.com/1650875/139281422-d6981afe-6145-4f3d-8baa-a5c06ed5efa6.png)
![image](https://user-images.githubusercontent.com/1650875/139281469-5a0f8d9b-2857-4f0f-9550-dc281302b070.png)
