### PR TITLE
Revert the way current/previous concerns are displayed

### DIFF
--- a/cypress/integration/case/case-risk.spec.ts
+++ b/cypress/integration/case/case-risk.spec.ts
@@ -72,9 +72,7 @@ context('Case risk tab', () => {
                 'Previous concerns about coping in custody and in a hostel',
                 () => {
                   page.currentNotes.contains('No detail given')
-                  page.previousNotes.contains(
-                    'Soluta tempore nemo et velit est perspiciatis. Neque error aut est nemo quasi. Et labore impedit omnis numquam id et eaque facere itaque. Ipsam et atque eos tempora possimus. A hostel setting would pose significant risk for this case.',
-                  )
+                  page.previousNotes.contains('A hostel setting would pose significant risk for this case.')
                 },
               )
               list.value('Vulnerability').contains('No concerns')

--- a/src/server/case/risk/risk.service.spec.ts
+++ b/src/server/case/risk/risk.service.spec.ts
@@ -63,13 +63,13 @@ describe('RiskService', () => {
             previous: RiskDtoAllRisksViewPrevious.No,
             previousConcernsText: null,
             current: RiskDtoAllRisksViewCurrent.Yes,
-            currentConcernsText: 'Some current concerns',
+            currentConcernsText: 'Some ignored current concerns',
           },
           selfHarm: {
             previous: RiskDtoAllRisksViewPrevious.Yes,
             previousConcernsText: null,
             current: RiskDtoAllRisksViewCurrent.Yes,
-            currentConcernsText: 'Some ignored current concerns',
+            currentConcernsText: 'Some current concerns',
           },
           custody: {
             previous: RiskDtoAllRisksViewPrevious.Yes,
@@ -139,7 +139,7 @@ describe('RiskService', () => {
         },
         self: {
           harm: {
-            notes: { current: 'Some current concerns\n\nSome ignored current concerns', previous: null },
+            notes: { current: 'Some current concerns', previous: null },
             value: 'Immediate concerns about suicide and self-harm',
           },
           custody: {

--- a/src/server/case/risk/risk.service.ts
+++ b/src/server/case/risk/risk.service.ts
@@ -261,15 +261,12 @@ function flattenRisks(
 
     if (risk.current === RiskDtoCurrent.Yes) {
       currentConcerns.push(name)
-      if (result.notes.current && risk.currentConcernsText) result.notes.current += '\n\n' + risk.currentConcernsText
-      else result.notes.current = risk.currentConcernsText
+      result.notes.current = risk.currentConcernsText
     }
 
     if (risk.previous === RiskDtoPrevious.Yes) {
       previousConcerns.push(name)
-      if (result.notes.previous && risk.previousConcernsText)
-        result.notes.previous += '\n\n' + risk.previousConcernsText
-      else result.notes.previous = risk.previousConcernsText
+      result.notes.previous = risk.previousConcernsText
     }
   }
 


### PR DESCRIPTION
Previously in https://github.com/ministryofjustice/hmpps-manage-supervisions/pull/385/commits/070950ef4f6bc450d62ce5be475073affb0324ae we changed the logic for displaying current and previous concerns.

According to http://ms-design-history.herokuapp.com/risk-tab/#incorporating-risk-of-harm-to-themselves this behaviour was intentional and should have been left as is, because Delius captures information for concerns in pairs (suicide is paired with self-harm for example) and the API exposes duplicated data.