### PR TITLE
Fix bug when displaying addresses in personal contacts

### DIFF
--- a/src/server/case/personal/personal-contact.njk
+++ b/src/server/case/personal/personal-contact.njk
@@ -27,8 +27,8 @@
                     } if personalContact.relationship,
                     {
                         key: { text: "Address" },
-                        value: { html: join(personalContact.address) }
-                    } if personalContact.address,
+                        value: { html: join(personalContact.address).trim() }
+                    } if join(personalContact.address).trim().length,
                     {
                         key: { text: "Phone number" },
                         value: { text: personalContact.phone }


### PR DESCRIPTION
If the address is empty or an empty string, we shouldn't display it.

https://trello.com/c/TMfZmPNe/943-snag-changes-to-personal-contacts

### Before

![image](https://user-images.githubusercontent.com/1650875/140090700-f4bb1566-6c2a-4034-9070-0174eae01b9f.png)


### After

![image](https://user-images.githubusercontent.com/1650875/140090591-97248a63-720c-4bf1-824d-34d60607765a.png)
