### PR TITLE
Fix personal contact snags

### DIFF
--- a/cypress/integration/case/case-personal.spec.ts
+++ b/cypress/integration/case/case-personal.spec.ts
@@ -29,7 +29,7 @@ class Fixture extends ViewCaseFixture {
 
   whenClickingViewPersonalContact(name: string) {
     return this.shouldRenderOffenderTab('personal', page => {
-      page.contactDetails(card => card.value('Personal contacts').contains(name).click())
+      page.contactDetails(card => card.value('Contacts').contains(name).click())
     })
   }
 
@@ -206,8 +206,8 @@ context('Case personal details tab', () => {
             })
 
             card.value('Other addresses').contains('1 other current address 1 previous address')
-            card.value('Personal contacts').contains('Next of Kin: Pippa Wade – Wife')
-            card.value('Personal contacts').contains('Family member: Jonathon Bacon – Father')
+            card.value('Contacts').contains('Next of Kin: Pippa Wade – Wife')
+            card.value('Contacts').contains('Family member: Jonathon Bacon – Father')
           })
 
           page.personalDetails(card => {

--- a/cypress/integration/case/case-personal.spec.ts
+++ b/cypress/integration/case/case-personal.spec.ts
@@ -345,6 +345,8 @@ context('Case personal details tab', () => {
           page.value(/^\s*Relationship\s*$/).contains('Wife')
           page.value('Address').contains('64 Ermin Street Wrenthorpe West Yorkshire WF2 8WT')
           page.value('Phone number').contains('07700 900 141')
+          page.value('Start date').contains('13 September 2019')
+          page.value('End date').contains('10 October 2200')
           page.value('Notes').contains('Divorced')
         })
         .whenClickingChangeContactDetails('Pippa Wade – Wife')

--- a/cypress/plugins/personal-contacts.ts
+++ b/cypress/plugins/personal-contacts.ts
@@ -7,6 +7,7 @@ export const PERSONAL_CONTACTS: DeepPartial<PersonalContact>[] = [
   {
     relationship: 'Wife',
     startDate: '2019-09-13T00:00:00',
+    endDate: '2200-10-10T00:00:00',
     title: 'Dr',
     firstName: 'Pippa',
     surname: 'Wade',

--- a/src/server/case/personal/personal-contact.njk
+++ b/src/server/case/personal/personal-contact.njk
@@ -15,7 +15,7 @@
                 rows: [
                     {
                         key: { text: "Name" },
-                        value: { text: personalContact.displayName }
+                        value: { text: personalContact.displayName if personalContact.displayName else 'No name' }
                     },
                     {
                         key: { text: "Relationship type" },

--- a/src/server/case/personal/personal-contact.njk
+++ b/src/server/case/personal/personal-contact.njk
@@ -1,5 +1,5 @@
 {% extends "partials/layout.njk" %}
-{% set pageTitle = 'Personal contact - ' + personalContact.description %}
+{% set pageTitle = 'Contact - ' + personalContact.description %}
 {% from '_join.njk' import join %}
 
 {% block content %}

--- a/src/server/case/personal/personal-contact.njk
+++ b/src/server/case/personal/personal-contact.njk
@@ -34,6 +34,14 @@
                         value: { text: personalContact.phone }
                     } if personalContact.phone,
                     {
+                        key: { text: "Start date" },
+                        value: { text: personalContact.startDate | shortDate }
+                    } if personalContact.startDate,
+                    {
+                        key: { text: "End date" },
+                        value: { text: personalContact.endDate | shortDate }
+                    } if personalContact.endDate,
+                    {
                         key: { text: "Notes" },
                         value: { text: personalContact.notes if personalContact.notes else "No notes" }
                     }

--- a/src/server/case/personal/personal.controller.ts
+++ b/src/server/case/personal/personal.controller.ts
@@ -106,7 +106,7 @@ export class PersonalController {
   @Breadcrumb({
     type: BreadcrumbType.PersonalContact,
     parent: BreadcrumbType.PersonalDetails,
-    title: x => `Personal contact: ${x.entityName}`,
+    title: x => `Contact: ${x.entityName}`,
   })
   async getPersonalContact(
     @Param('crn') crn: string,
@@ -119,7 +119,7 @@ export class PersonalController {
 
     const personalContact = personalContacts.find(x => x.id === id)
     if (!personalContact) {
-      throw new NotFoundException(`Personal contact with id ${id} does not exist`)
+      throw new NotFoundException(`Contact with id ${id} does not exist`)
     }
 
     return {

--- a/src/server/case/personal/personal.njk
+++ b/src/server/case/personal/personal.njk
@@ -86,8 +86,8 @@
                     value: { html: otherAddresses }
                 },
                 {
-                    key: { text: 'Personal contacts' },
-                    value: { html: personalContacts if personalContacts else 'No personal contacts' }
+                    key: { text: 'Contacts' },
+                    value: { html: personalContacts if personalContacts else 'No contacts' }
                 }
             ]
         }) }}


### PR DESCRIPTION
- Rename personal contacts to contacts
- Display start and end dates for contacts
- Don't show contact displayName when empty 

### After

Note title, breadcrumb, and start/end dates.

![image](https://user-images.githubusercontent.com/1650875/140098055-98816dd7-8ee4-4cb9-93b1-a00652f16128.png)

With no name:

![image](https://user-images.githubusercontent.com/1650875/140165289-87813562-a893-4cc4-a2cd-f677f4dd48f0.png)

