### PR TITLE
Fix record outcome link being displayed when it shouldn't

### DIFF
--- a/cypress/integration/case/case-activity.spec.ts
+++ b/cypress/integration/case/case-activity.spec.ts
@@ -285,6 +285,17 @@ context('Case activity tab', () => {
         .shouldDisplayExitPage('delius')
     })
 
+    it('does not display record outcome on future appointments', () => {
+      fixture
+        .whenViewingOffender()
+        .whenClickingSubNavTab('activity')
+        .shouldRenderOffenderTab('activity', page => {
+          page.group('Wednesday 10 October 2035', group => {
+            group.entry(13, card => card.actions.should('not.exist'))
+          })
+        })
+    })
+
     it('displays system contact on activity log with link to delius', () => {
       fixture
         .whenViewingOffender()

--- a/cypress/plugins/contacts.ts
+++ b/cypress/plugins/contacts.ts
@@ -264,6 +264,24 @@ export const ACTIVITY_LOG_GROUPS: DeepPartial<ActivityLogGroup>[] = [
       },
     ],
   },
+  {
+    date: '2035-10-10',
+    rarDay: false,
+    entries: [
+      {
+        contactId: 13,
+        convictionId: ACTIVE_CONVICTION_ID,
+        type: { code: 'NOT_WELL_KNOWN', description: 'Not a well known appointment', appointment: true },
+        startTime: '11:00:00',
+        endTime: '13:00:00',
+        notes: 'Future appointment with no outcome',
+        staff: { forenames: 'Brian', surname: 'Northgate', unallocated: false },
+        outcome: null,
+        sensitive: false,
+        rarActivity: null,
+      },
+    ],
+  },
 ]
 
 type CommonContactApiQuery = Omit<

--- a/src/server/case/activity/activity.njk
+++ b/src/server/case/activity/activity.njk
@@ -49,7 +49,7 @@
         titleHtml: title,
         classes: 'govuk-!-margin-bottom-2',
         attributes: { 'data-qa': 'offender/activity/' + entry.id },
-        actions: { items: [{ href: entry.links.recordMissingAttendance, text: "Record an outcome" }] } if not entry.outcome,
+        actions: { items: [{ href: entry.links.recordMissingAttendance, text: "Record an outcome" }] } if entry.links.recordMissingAttendance,
         actionsHtml: govukTag({ text: entry.outcome.tag.name, classes: entry.outcome.tag.colour | tagClassName + ' govuk-!-margin-left-2' }) if entry.outcome,
         headingLevel: 4
     }) -%}


### PR DESCRIPTION
For future appointments we were showing a "record an outcome" link with no href, when we shouldn't have been showing the link at all  