### PR TITLE
Improve content for Record an outcome link

### DIFF
--- a/src/server/case/activity/activity.njk
+++ b/src/server/case/activity/activity.njk
@@ -49,7 +49,7 @@
         titleHtml: title,
         classes: 'govuk-!-margin-bottom-2',
         attributes: { 'data-qa': 'offender/activity/' + entry.id },
-        actions: { items: [{ href: entry.links.recordMissingAttendance, text: "Record an outcome" }] } if entry.links.recordMissingAttendance,
+        actions: { items: [{ href: entry.links.recordMissingAttendance, html: 'Record an outcome<span class="govuk-visually-hidden"> for ' + entry.name + ' at ' + (entry.start | time) + '</span>' }] } if entry.links.recordMissingAttendance,
         actionsHtml: govukTag({ text: entry.outcome.tag.name, classes: entry.outcome.tag.colour | tagClassName + ' govuk-!-margin-left-2' }) if entry.outcome,
         headingLevel: 4
     }) -%}


### PR DESCRIPTION
Add additional context for assistive technology users, by appending the entry name and start time.

https://trello.com/c/SVcw3Hnj/903-dac-fix-multiple-instances-of-non-descriptive-links

### After

![image](https://user-images.githubusercontent.com/1650875/141151670-289b3132-a9c5-4c18-9e07-08f65e36c2b6.png)
