### PR TITLE
Make timestamp part of activity links

### DIFF
--- a/src/server/case/activity/activity.njk
+++ b/src/server/case/activity/activity.njk
@@ -31,11 +31,15 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro appointmentCard(entry, open) -%}
+{% macro appointmentCard(entry, open, date) -%}
     {% set title %}
         <span class="govuk-heading-s govuk-!-margin-bottom-0">
-            <a href="{{ entry.links.view }}">{{ entry.name }}</a>
-            <span class="govuk-!-font-weight-regular">at&nbsp;{{ entry.start | time }}</span>
+            <a href="{{ entry.links.view }}">{{ entry.name }}
+                <span class="govuk-!-font-weight-regular">at&nbsp;{{ entry.start | time }}</span>
+                <span class="govuk-visually-hidden">
+                    on {{ date | longDate }}
+                </span>
+            </a>
         </span>
         <span class='govuk-!-font-size-16' data-qa='sub-title'>
             {% if entry.nationalStandard %}
@@ -68,12 +72,17 @@
     {%- endcall %}
 {%- endmacro %}
 
-{% macro plainCard(entry, open, options) -%}
+{% macro plainCard(entry, open, date, options) -%}
     {% set title %}
-        <a href="{{ entry.links.view }}">{{ entry.name }}</a>
-        {% if options.time %}
-            <span class="govuk-!-font-weight-regular">at&nbsp;{{ entry.start | time }}</span>
-        {% endif %}
+        <a href="{{ entry.links.view }}">
+            {{ entry.name }}
+            {% if options.time %}
+                <span class="govuk-!-font-weight-regular">at&nbsp;{{ entry.start | time }}</span>
+            {% endif %}
+            <span class="govuk-visually-hidden">
+                on {{ date | longDate }}
+            </span>
+        </a>
     {% endset %}
     {% call appSummaryCard({
         titleHtml: title,
@@ -133,13 +142,13 @@
                         {% set open = index < 4 %}
                         {% switch entry.type %}
                         {% case 'appointment' %}
-                            {{ appointmentCard(entry, open) }}
+                            {{ appointmentCard(entry, open, group.date) }}
                         {% case 'communication' %}
-                            {{ plainCard(entry, open, { time: true }) }}
+                            {{ plainCard(entry, open, group.date, { time: true }) }}
                         {% case 'system' %}
                             {{ systemContact(entry) }}
                         {% default %}
-                            {{ plainCard(entry, open) }}
+                            {{ plainCard(entry, open, group.date) }}
                         {% endswitch %}
                     {% endfor %}
                 </section>


### PR DESCRIPTION
This improves their legibility for assistive technology users by differentiating them in the page.

https://trello.com/c/SVcw3Hnj/903-dac-fix-multiple-instances-of-non-descriptive-links

### After

![image](https://user-images.githubusercontent.com/1650875/141153978-21411835-acf2-4d5b-8f96-5ce4074f0db1.png)
