### PR TITLE
Improve date validation messages

### DIFF
--- a/cypress/integration/appointments/arrange-appointment.spec.ts
+++ b/cypress/integration/appointments/arrange-appointment.spec.ts
@@ -209,9 +209,21 @@ context('Arrange appointment happy path & validation', () => {
 
     offendersCircumstancesAreShown()
 
+    whenEnteringDateStrings('', '', '')
+    whenSubmittingCurrentStep()
+    aDateErrorIsShown('Enter the date of the appointment')
+
+    whenEnteringDateStrings('80', '', '')
+    whenSubmittingCurrentStep()
+    aDateErrorIsShown('Date must include a month and year')
+
+    whenEnteringDateStrings('', '20', '')
+    whenSubmittingCurrentStep()
+    aDateErrorIsShown('Date must include a day and year')
+
     whenEnteringDateStrings('80', '20', '6')
     whenSubmittingCurrentStep()
-    aDateErrorIsShown('Enter a valid date')
+    aDateErrorIsShown('Date must be a real date')
     aStartTimeErrorIsShown('Enter a valid start time')
     aEndTimeErrorIsShown('Enter a valid end time')
 
@@ -464,9 +476,12 @@ context('Arrange appointment happy path & validation', () => {
   }
 
   function whenEnteringDateStrings(day: string, month: string, year: string) {
-    page.when.dayField.clear().type(day)
-    page.when.monthField.clear().type(month)
-    page.when.yearField.clear().type(year)
+    page.when.dayField.clear()
+    page.when.monthField.clear()
+    page.when.yearField.clear()
+    if (day) page.when.dayField.clear().type(day)
+    if (month) page.when.monthField.clear().type(month)
+    if (year) page.when.yearField.clear().type(year)
   }
 
   function whenEnteringStartTime(time: DateTime) {

--- a/src/server/arrange-appointment/dto/AppointmentBuilderDto.spec.ts
+++ b/src/server/arrange-appointment/dto/AppointmentBuilderDto.spec.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 import { fakeAppointmentBuilderDto } from './arrange-appointment.fake'
-import { IS_BOOLEAN, IS_IN, IS_INT, IS_NOT_EMPTY, IS_POSITIVE, IS_STRING, validate } from 'class-validator'
+import { IS_BOOLEAN, IS_IN, IS_NOT_EMPTY, IS_STRING, validate } from 'class-validator'
 import { AppointmentBuilderDto } from './AppointmentBuilderDto'
 import { flattenValidationErrors } from '../../util/flattenValidationErrors'
 import { DateTime } from 'luxon'
@@ -243,9 +243,6 @@ describe('AppointmentBuilderDto validation & mapping', () => {
       })
         .whenValidating(AppointmentWizardStep.When)
         .shouldTriggerConstraints('date', IS_DATE_INPUT)
-        .shouldTriggerConstraints('date.day', IS_POSITIVE)
-        .shouldTriggerConstraints('date.month', IS_POSITIVE)
-        .shouldTriggerConstraints('date.year', IS_POSITIVE)
         .shouldTriggerConstraints('startTime', IS_TIME)
         .shouldTriggerConstraints('endTime', IS_TIME)
         .run())
@@ -258,9 +255,6 @@ describe('AppointmentBuilderDto validation & mapping', () => {
       })
         .whenValidating(AppointmentWizardStep.When)
         .shouldTriggerConstraints('date', IS_DATE_INPUT)
-        .shouldTriggerConstraints('date.day', IS_INT, IS_POSITIVE)
-        .shouldTriggerConstraints('date.month', IS_INT, IS_POSITIVE)
-        .shouldTriggerConstraints('date.year', IS_INT, IS_POSITIVE)
         .shouldTriggerConstraints('startTime', IS_TIME)
         .shouldTriggerConstraints('endTime', IS_TIME)
         .run())


### PR DESCRIPTION
Implement more specific date validation error messages following [best practice from the GOVUK design system](https://design-system.service.gov.uk/components/date-input/#error-messages).

### After

![image](https://user-images.githubusercontent.com/1650875/141481935-bd1769d0-baef-419e-8820-5aaab14dd0f2.png)
![image](https://user-images.githubusercontent.com/1650875/141481872-0726c6c0-81de-47ca-9db1-2a334767a35a.png)
![image](https://user-images.githubusercontent.com/1650875/141481907-aaf254f6-2f1d-4fe5-8820-ce5fefe98812.png)
