### PR TITLE
Do not reorder messages when flattening validation errors

### DIFF
--- a/src/server/util/flattenValidationErrors.spec.ts
+++ b/src/server/util/flattenValidationErrors.spec.ts
@@ -30,6 +30,6 @@ describe('flattenValidationErrors', () => {
 
     const observed = flattenValidationErrors(errors)
 
-    expect(observed).toEqual(expect.arrayContaining(expected))
+    expect(observed).toEqual(expected)
   })
 })

--- a/src/server/util/flattenValidationErrors.ts
+++ b/src/server/util/flattenValidationErrors.ts
@@ -9,7 +9,7 @@ export function flattenValidationErrors(errors: ValidationError[]): FlatValidati
   const toVisit = [...errors]
   const result: FlatValidationError[] = []
   while (toVisit.length > 0) {
-    const error = toVisit.pop()
+    const error = toVisit.shift()
     if (error.children?.length > 0) {
       toVisit.push(...error.children.map(x => ({ ...x, property: `${error.property}.${x.property}` })))
     }


### PR DESCRIPTION
Use .shift instead of .pop to respect the initial order of error messages.

## Before

![image](https://user-images.githubusercontent.com/1650875/142204139-aa273399-2620-48aa-8548-7dd8f6195c10.png)

## After

![image](https://user-images.githubusercontent.com/1650875/142204164-f46c751b-46ac-42b2-a82a-932e4ceb168e.png)
