### PR TITLE
Display "Length not set" when requirement length isn't set

### DIFF
--- a/src/server/community-api/conviction/requirement.service.spec.ts
+++ b/src/server/community-api/conviction/requirement.service.spec.ts
@@ -26,7 +26,7 @@ describe('RequirementService', () => {
     const options: GetConvictionRequirementsOptions = { crn: 'some-crn', convictionId: 100 }
     const rarRequirement1 = fakeRequirement({
       requirementId: 1,
-      length: 4,
+      length: 0,
       lengthUnit: 'Day',
       requirementNotes: 'RAR 1',
       startDate: '2020-06-20',
@@ -73,18 +73,19 @@ describe('RequirementService', () => {
     expect(observed).toEqual([
       {
         type: ConvictionRequirementType.Aggregate,
-        name: '9 days RAR',
+        name: '5 days RAR',
         isRar: true,
         requirements: [
           {
             id: 1,
-            length: '4 days',
+            length: 'Length not set',
             notes: 'RAR 1',
             startDate: {
               value: DateTime.fromObject({ year: 2020, month: 6, day: 20 }),
               expected: false,
             },
             endDate: null,
+            terminationReason: undefined,
           },
           {
             id: 2,
@@ -98,6 +99,7 @@ describe('RequirementService', () => {
               value: DateTime.fromObject({ year: 2021, month: 12, day: 20 }),
               expected: true,
             },
+            terminationReason: undefined,
           },
         ],
       },
@@ -110,6 +112,7 @@ describe('RequirementService', () => {
         notes: 'Plain old requirement',
         startDate: null,
         endDate: null,
+        terminationReason: undefined,
       },
       {
         id: 4,
@@ -126,6 +129,7 @@ describe('RequirementService', () => {
           value: DateTime.fromObject({ year: 2021, month: 2, day: 1 }),
           expected: false,
         },
+        terminationReason: undefined,
       },
     ] as ConvictionRequirement[])
   })

--- a/src/server/community-api/conviction/requirement.service.ts
+++ b/src/server/community-api/conviction/requirement.service.ts
@@ -100,7 +100,7 @@ export class RequirementService {
   private static getRequirementDetail(req: Requirement): ConvictionRequirementDetail {
     return {
       id: req.requirementId,
-      length: quantity(req.length, req.lengthUnit.toLowerCase()),
+      length: req.length ? quantity(req.length, req.lengthUnit.toLowerCase()) : 'Length not set',
       notes: req.requirementNotes,
       startDate: getPotentiallyExpectedDateTime(req.startDate, req.expectedStartDate),
       endDate: getPotentiallyExpectedDateTime(req.terminationDate, req.expectedEndDate),


### PR DESCRIPTION
Currently we display "undefined days" which looks wrong.

https://trello.com/c/DdBLWe20/1055-snag-changes-to-sentence-page

### Before

![image](https://user-images.githubusercontent.com/1650875/146051719-d4cc943c-4beb-4e67-9e7a-9f7daf80f26b.png)

### After

![image](https://user-images.githubusercontent.com/1650875/146051873-29e0ebc3-33a1-4b77-be08-8eb0f0588767.png)
